### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,15 @@ localsrv
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/django-localsrv
 
-.. |wheel| image:: https://pypip.in/wheel/django-localsrv/badge.png?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/django-localsrv.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/django-localsrv
 
-.. |supported-versions| image:: https://pypip.in/py_versions/django-localsrv/badge.png?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/django-localsrv.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/django-localsrv
 
-.. |supported-implementations| image:: https://pypip.in/implementation/django-localsrv/badge.png?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/django-localsrv.svg?style=flat
     :alt: Supported imlementations
     :target: https://pypi.python.org/pypi/django-localsrv
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-localsrv))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-localsrv`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.